### PR TITLE
Fix systematics logic

### DIFF
--- a/heppi.py
+++ b/heppi.py
@@ -194,7 +194,7 @@ def MakeStatProgression(myHisto,histDwSys={},histUpSys={}, title=""):
     return statPrecision
 
 #---------------------------------------------------------
-def drawStatErrorBand(myHisto,histDwSys={},histUpSys={}):
+def drawStatErrorBand(myHisto,histDwSys={},histUpSys={},actuallyDrawSystErrorBand=True):
     """
     Draw this histogram with the statistical
     precision error in each bin
@@ -203,37 +203,28 @@ def drawStatErrorBand(myHisto,histDwSys={},histUpSys={}):
     ROOT.SetOwnership(statPrecision,0)
     statPrecision.SetFillColorAlpha(2, 0.5)
     statPrecision.SetMarkerColorAlpha(0,0)
-    
-    for ibin in range(myHisto.GetNbinsX()+1):
-        y   = statPrecision.GetBinContent(ibin);
-        err = statPrecision.GetBinError  (ibin);
-#        sys_up = 0
-#        sys_dw = 0
-#        for sys in histUpSys:
-#            er = abs(y - histUpSys[sys].GetBinContent(ibin));
-#            print '(%f, %f)' % (y, histUpSys[sys].GetBinContent(ibin) )
-#            sys_up = max(sys_up, er)
-#        for sys in histDwSys:
-#            er = abs(y - histDwSys[sys].GetBinContent(ibin));
-#            sys_dw = max(sys_dw, er)
 
-        vals = [y]
-        print "Central:",y
-        for sys in histUpSys:
-            val = histUpSys[sys].GetBinContent(ibin)
-            vals += [val]
-            print sys,val
-        for sys in histDwSys:
-            val= histDwSys[sys].GetBinContent(ibin)
-            vals += [val]
-            print sys,val
-     
-        largest_val  = max(vals)
-        smallest_val = min(vals)
-
+    if actuallyDrawSystErrorBand:
+        for ibin in range(myHisto.GetNbinsX()+1):
+            y   = statPrecision.GetBinContent(ibin);
+            err = statPrecision.GetBinError  (ibin);
             
-        statPrecision.SetBinContent(ibin,   (largest_val + smallest_val)/2.0);
-        statPrecision.SetBinError  (ibin,   (largest_val - smallest_val)/2.0);
+            vals = [y]
+            print "Central:",y
+            for sys in histUpSys:
+                val = histUpSys[sys].GetBinContent(ibin)
+                vals += [val]
+                print sys,val
+            for sys in histDwSys:
+                val= histDwSys[sys].GetBinContent(ibin)
+                vals += [val]
+                print sys,val
+     
+            largest_val  = max(vals)
+            smallest_val = min(vals)
+
+            statPrecision.SetBinContent(ibin,   (largest_val + smallest_val)/2.0);
+            statPrecision.SetBinError  (ibin,   (largest_val - smallest_val)/2.0);
         
     return statPrecision
     #if norm:

--- a/heppi.py
+++ b/heppi.py
@@ -207,21 +207,33 @@ def drawStatErrorBand(myHisto,histDwSys={},histUpSys={}):
     for ibin in range(myHisto.GetNbinsX()+1):
         y   = statPrecision.GetBinContent(ibin);
         err = statPrecision.GetBinError  (ibin);
-        sys_up = 0
-        sys_dw = 0
+#        sys_up = 0
+#        sys_dw = 0
+#        for sys in histUpSys:
+#            er = abs(y - histUpSys[sys].GetBinContent(ibin));
+#            print '(%f, %f)' % (y, histUpSys[sys].GetBinContent(ibin) )
+#            sys_up = max(sys_up, er)
+#        for sys in histDwSys:
+#            er = abs(y - histDwSys[sys].GetBinContent(ibin));
+#            sys_dw = max(sys_dw, er)
+
+        vals = [y]
+        print "Central:",y
         for sys in histUpSys:
-            er = abs(y - histUpSys[sys].GetBinContent(ibin));
-            print '(%f, %f)' % (y, histUpSys[sys].GetBinContent(ibin) )
-            sys_up = max(sys_up, er)
+            val = histUpSys[sys].GetBinContent(ibin)
+            vals += [val]
+            print sys,val
         for sys in histDwSys:
-            er = abs(y - histDwSys[sys].GetBinContent(ibin));
-            sys_dw = max(sys_dw, er)
+            val= histDwSys[sys].GetBinContent(ibin)
+            vals += [val]
+            print sys,val
+     
+        largest_val  = max(vals)
+        smallest_val = min(vals)
+
             
-            # maxerr = max(sys_up,sys_dw)
-            #minerr = min(sys_up,sys_dw)
-        
-        #statPrecision.SetBinContent(ibin,   (sys_up + sys_dw)/2.0);
-        #statPrecision.SetBinError  (ibin,abs(sys_up - sys_dw)/2.0);
+        statPrecision.SetBinContent(ibin,   (largest_val + smallest_val)/2.0);
+        statPrecision.SetBinError  (ibin,   (largest_val - smallest_val)/2.0);
         
     return statPrecision
     #if norm:


### PR DESCRIPTION
This implements my approach to the logic for drawing the systematics band, which was the following for each bin:

* largest_val = max(bin contents for all systematics)
* smallest_val = min(bin contents for all systematics)
* Systematics central (not plotted):  (largest_val + smallest_val)/2.0
* Systematics "uncertainty":   largest_val - smallest_val)/2.0

In other words, the pink band would just go from smallest_val to largest_val.  Note that the min and max run over "up" systematics, "down" systematics, and also the central value.  This is because shifting a systematic (e.g. the JEC) up/down may increase the entries in some bins and decrease it in others, and indeed it's actually possible that both up and down will move the contents in the same direction, so that the central value is largest_val or smallest_val.

The previous version had (min+max)/2 and abs(max-min)/2, but min and max were taken from the deviations of the systematics from the central value.  Thus the pink band range covered something proportional to the systematic uncertainty, but didn't run from below the central value to above it, as we saw on the plots on Friday.

Finally, I added an argument called actuallyDrawSystErrorBand to make it clearer when reading the code that this function is replacing the statistical uncertainties with systematic ones (and allow shifts between them).  In the future we should have a stat method, a syst method, a combined method, and options/choices for which to draw.

Let me know if this all makes sense!